### PR TITLE
qmf: fix undefined behavior in Vector::data

### DIFF
--- a/qmf/Vector.h
+++ b/qmf/Vector.h
@@ -39,7 +39,7 @@ class Vector {
   }
 
   Double* const data() {
-    return &data_[0];
+    return data_.data();
   }
 
  private:


### PR DESCRIPTION
Taking an address of the 0th element -- as in `&data_[0]` -- is undefined behavior for an empty vector `data_`.

Conceptually, attempting to access non-existing element `data_[0]` can happen regardless of whether its address is being taken or not.

As C++14 is among the requirements, a simple fix is to just use `std::vector<Double>::data` (available since C++11), which always does the right thing:
http://en.cppreference.com/w/cpp/container/vector/data

More details:
http://www.gotw.ca/gotw/074.htm
https://stackoverflow.com/questions/2728255/c-getting-the-address-of-the-start-of-an-stdvector
https://stackoverflow.com/questions/681725/what-do-i-get-from-front-of-empty-std-container
https://stackoverflow.com/questions/25419851/what-should-stdvectordata-return-if-the-vector-is-empty