### PR TITLE
wals: fix loss computation

### DIFF
--- a/qmf/bpr/BPREngine.cpp
+++ b/qmf/bpr/BPREngine.cpp
@@ -17,6 +17,7 @@
 #include <qmf/bpr/BPREngine.h>
 
 #include <algorithm>
+#include <cmath>
 
 namespace qmf {
 
@@ -180,6 +181,8 @@ void BPREngine::update(const PosNegTriplet& triplet) {
   const size_t nidx = triplet.negItemIdx;
 
   const Double e = lossDerivative(predictDifference(uidx, pidx, nidx));
+  CHECK(std::isfinite(e)) << "gradients too big, try decreasing the learning "
+                             "rate (--init_learning_rate)";
   const Double lr = learningRate_;
 
   // update biases

--- a/qmf/test/WALSEngineTest.cpp
+++ b/qmf/test/WALSEngineTest.cpp
@@ -186,6 +186,21 @@ TEST(WALSEngine, updateFactorsForOne) {
       EXPECT_NEAR(X(i, j), 0.0, 1e-8);
     }
   }
-  EXPECT_NEAR(loss, 11.188, 1e-2);
+
+  Double trueLoss = 0.0;
+  for (size_t i = 0; i < nusers; ++i) {
+    for (size_t j = 0; j < nitems; ++j) {
+      Double pred = 0.0;
+      for (size_t k = 0; k < nfactors; ++k) {
+        pred += X(i, k) * Y(j, k);
+      }
+      if (i == 0) { // both items liked for this user
+        trueLoss += 2.0 * (1.0 - pred) * (1.0 - pred);
+      } else {
+        trueLoss += (0.0 - pred) * (0.0 - pred);
+      }
+    }
+  }
+  EXPECT_NEAR(loss, trueLoss, 1e-2);
 }
 }

--- a/qmf/wals/WALSEngine.cpp
+++ b/qmf/wals/WALSEngine.cpp
@@ -226,9 +226,9 @@ Double WALSEngine::updateFactorsForOne(Matrix& X,
       for (size_t j = 0; j < n; ++j) {
         A(i, j) += Y(rightIdx, i) * alpha * signal.value * Y(rightIdx, j);
       }
-      // for term p^t * C * p
-      loss += 1.0 + alpha * signal.value;
     }
+    // for term p^t * C * p
+    loss += 1.0 + alpha * signal.value;
   }
   // B = Y^t * C * Y
   Matrix B = A;


### PR DESCRIPTION
There was a bug in the computation of the loss for WALS. I also added a check for finite gradients in BPR (see https://github.com/quora/qmf/issues/11).