### PR TITLE
bpr: fix optimize test on clang

### DIFF
--- a/qmf/test/BPREngineTest.cpp
+++ b/qmf/test/BPREngineTest.cpp
@@ -87,6 +87,8 @@ TEST(BPREngine, optimize) {
   config.decayRate = 1.0;
   config.initDistributionBound = 0.1;
   config.numNegativeSamples = 1;
+  config.numHogwildThreads = 2;
+  config.useBiases = false;
 
   int totalChecks = 0;
   int successChecks = 0;


### PR DESCRIPTION
BPREngineTest was failing/blocking on my mac with clang.