### PR TITLE
fix: 'std::bind' include error for gcc version larger than 7.

### DIFF
--- a/qmf/utils/ThreadPool-inl.h
+++ b/qmf/utils/ThreadPool-inl.h
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+#if __GNUC__ >= 7
+ #include <functional>
+#endif
+
 #include <condition_variable>
 
 #include <glog/logging.h>


### PR DESCRIPTION
If not, for gcc with version larger than 7, following compiling error will be raised:
```
/qmf/qmf/utils/ThreadPool-inl.h:36:10: error: ‘bind’ is not a member of ‘std’
     std::bind(std::forward<FuncT>(func), std::forward<Args>(args)...));
```
Following are the testing results:
```
Running tests...
Test project /home/liuyutong/project/personal/tmp/qmf/build
      Start  1: BPREngineTest
 1/12 Test  #1: BPREngineTest ....................   Passed    0.47 sec
      Start  2: DatasetReaderTest
 2/12 Test  #2: DatasetReaderTest ................   Passed    0.13 sec
      Start  3: EngineTest
 3/12 Test  #3: EngineTest .......................   Passed    0.05 sec
      Start  4: FactorDataTest
 4/12 Test  #4: FactorDataTest ...................   Passed    0.18 sec
      Start  5: MatrixTest
 5/12 Test  #5: MatrixTest .......................   Passed    0.25 sec
      Start  6: MetricsTest
 6/12 Test  #6: MetricsTest ......................   Passed    0.00 sec
      Start  7: MetricsManagerTest
 7/12 Test  #7: MetricsManagerTest ...............   Passed    0.00 sec
      Start  8: ParallelExecutorTest
 8/12 Test  #8: ParallelExecutorTest .............   Passed    0.00 sec
      Start  9: ThreadPoolTest
 9/12 Test  #9: ThreadPoolTest ...................   Passed    0.00 sec
      Start 10: UtilTest
10/12 Test #10: UtilTest .........................   Passed    0.00 sec
      Start 11: VectorTest
11/12 Test #11: VectorTest .......................   Passed    0.00 sec
      Start 12: WALSEngineTest
12/12 Test #12: WALSEngineTest ...................   Passed    0.33 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   1.43 sec
```