### PR TITLE
Fix missing includes

### DIFF
--- a/qmf/utils/IdIndex.h
+++ b/qmf/utils/IdIndex.h
@@ -19,6 +19,10 @@
 #include <limits>
 #include <vector>
 #include <unordered_map>
+#include <cstddef>
+#include <cstdint>
+using std::size_t;
+using std::int64_t;
 
 namespace qmf {
 


### PR DESCRIPTION
This library is missing some includes and fails to compile with GCC11 and the latest versions of the dependencies. This short PR fixes it.